### PR TITLE
Make linux installer script a bash script by default

### DIFF
--- a/linux/observability-agent-autoconf.sh
+++ b/linux/observability-agent-autoconf.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Flags
 while [ "$#" -gt 0 ]; do
   case "$1" in


### PR DESCRIPTION
Parts of the script are bash only.

- loading env from file - `source .env`
- setting prompted answers to lowercase `ans,,`
maybe others

Change `sh` to `bash` so it runs as bash when executing the script `./observability-agent-autoconf.sh`
